### PR TITLE
retry build molecule

### DIFF
--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -43,6 +43,10 @@ jobs:
         run: echo $DATA > ./google-services.json
 
       - name: Build Molecule
-        run: |
-          cd ${{ inputs.molecule_path }}
-          pattern molecule build -t ${{ inputs.tag }} --with_cloud_cache=${{ inputs.with_cloud_cache }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: |
+            cd ${{ inputs.molecule_path }}
+            pattern molecule build -t ${{ inputs.tag }} --with_cloud_cache=${{ inputs.with_cloud_cache }}

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -42,11 +42,14 @@ jobs:
           DATA: "${{ secrets.GOOGLE_CLOUD_BUILD_CACHE_ACCESS_KEY }}"
         run: echo $DATA > ./google-services.json
 
+      # we were experiencing some flakiness with authorizing with Docker,
+      # try again if we hit an issue and hope it's just flake
       - name: Build Molecule
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 15
-          max_attempts: 3
+          # takes ~12.5 min a run, but flake should cut out early
+          timeout_minutes: 25
+          max_attempts: 2
           command: |
             cd ${{ inputs.molecule_path }}
             pattern molecule build -t ${{ inputs.tag }} --with_cloud_cache=${{ inputs.with_cloud_cache }}

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -47,8 +47,8 @@ jobs:
       - name: Build Molecule
         uses: nick-fields/retry@v3
         with:
-          # takes ~12.5 min a run, but flake should cut out early
-          timeout_minutes: 25
+          # can take ~14 min a run, but flake should cut out early
+          timeout_minutes: 30
           max_attempts: 2
           command: |
             cd ${{ inputs.molecule_path }}


### PR DESCRIPTION
## Description
might close https://github.com/Pattern-Labs/the_cloud/issues/4384 

we been done havin docker flakiness (e.g. [this run](https://github.com/Pattern-Labs/the_cloud/actions/runs/17842103857/job/50733836434))

**Q**: could this just be an env issue, and we luck out by getting on a different VM on subsequent retries?
**A**: i don't think so, as in the case of the above run, the failing case had the environment
```
Current runner version: '2.328.0'
Runner name: 'github-hosted-cloud-builder_b711a1cf992a'
Runner group name: 'github-hosted'
Machine name: 'runnervmf4ws1'
Operating System
  Ubuntu
  24.04.3
  LTS
Runner Image
  Image: ubuntu-24.04
  Version: 20250907.24.1
  Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24

```
and the succeeding followup had
```
 Current runner version: '2.328.0'
Runner name: 'github-hosted-cloud-builder_e60e320e9fe6'
Runner group name: 'github-hosted'
Machine name: 'runnervmf4ws1'
Operating System
  Ubuntu
  24.04.3
  LTS
Runner Image
  Image: ubuntu-24.04
  Version: 20250907.24.1
  Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24
```

which seems to be the same environment

so if it's not environment specific, it might just be flake! unless it's rate limiting or something else, in which case this would exacerbate the issue, so let's hope it's not that :) 

### Customer-Facing Description
we be the customers: your PR checks will never fail again!

## Testing
not sure the best way to do this
- open a PR on a cloud branch to use this version: https://github.com/Pattern-Labs/the_cloud/pull/4400
    - :heavy_check_mark: doesn't break it from working the first time: [run #1](https://github.com/Pattern-Labs/the_cloud/actions/runs/17842611569)
    - :heavy_check_mark: : retries it if it fails: [run #3](https://github.com/Pattern-Labs/the_cloud/actions/runs/17843629033/job/50738614220?pr=4400)
    - :question: flake vs hard failure

## Documentation
comments for posterity
