### PR TITLE
feat: optionally add the Pattern CLI to /usr/bin

### DIFF
--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -1,5 +1,10 @@
 name: 'Pattern CLI Setup'
 description: 'Setup Pattern CLI'
+inputs:
+  add_to_usr_bin:
+    description: 'If true, copies the Pattern CLI to /usr/bin'
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -15,6 +20,11 @@ runs:
     - name: Make Pattern CLI executable
       shell: bash
       run: chmod +x ~/.local/bin/pattern
+
+    - name: Optionally add to /usr/bin
+      if: inputs.add_to_usr_bin == 'true'
+      shell: bash
+      run: sudo cp ~/.local/bin/pattern /usr/bin/pattern
 
     - name: Test Pattern CLI
       shell: bash 


### PR DESCRIPTION
## Description
Adds an optional `cp` to the `pattern_cli` action that will copy the Pattern CLI to `/usr/bin`.

### Customer-Facing Description

## Testing
I called the action from the [workflow](https://github.com/Pattern-Labs/the_cloud/actions/workflows/test_molecule.yaml) I am working on with `add_to_usr_bin` unset. It defaulted to `false` and the new `cp` command was **not** run. So existing workflows should use the existing behaviour and not be impacted.

I also ran the action with:
```
      - name: Install the Pattern CLI
        uses: Pattern-Labs/.github/.github/actions/pattern_cli@pattern-cli-on-usr-bin
        with:
          add_to_usr_bin: true
```

And it did the `cp` as expected

## Documentation

