### PR TITLE
setup_cloud_deps to have the same inputs / configurable behavior

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,19 @@
+# Used by actionlint (https://github.com/rhysd/actionlint)
+
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - github-hosted-cloud-builder
+    - aspect-small
+    - aspect-default
+    - aspect-warming
+    - aspect-workflows
+
+# Path-specific configurations.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    # List of regular expressions to filter errors by the error messages.
+    ignore:
+      # Ignore the a specific errorfrom regex linting
+      - ^invalid glob pattern\. unexpected character '\]' while checking character match \[\]\. character match with single character is useless\. simply use x instead of \[x\].*$

--- a/.github/actions/gke_cloud_auth/action.yml
+++ b/.github/actions/gke_cloud_auth/action.yml
@@ -1,0 +1,20 @@
+name: 'GKE Cloud Auth Setup'
+description: 'Setup GKE Cloud Auth'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Google Cloud SDK apt keys
+      shell: bash
+      run: |
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/cloud.google.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+    - name: Apt Update
+      shell: bash
+      run: sudo apt-get update -y
+
+    - name: Install gke-gcloud-auth-plugin
+      shell: bash
+      run: |
+        sudo apt install -y \
+        google-cloud-sdk-gke-gcloud-auth-plugin

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth }}
-      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@lb/conslidate_setup_cloud_deps
 
     - name: Setup Bazel
       if: ${{ inputs.setup_bazel }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -7,43 +7,38 @@ inputs:
   repo_access_pat:
     description: 'GitHub Personal Access Token'
     required: true
-    type: string
   docker_user:
     description: 'Docker Hub Username'
     required: true
-    type: string
   docker_password:
     description: 'Docker Hub Password'
     required: true
-    type: string
   helm_user:
     description: 'Harbor Registry Username'
     required: true
-    type: string
   helm_password:
     description: 'Harbor Registry Password'
     required: true
-    type: string
   pattern_cli_add_to_usr_bin:
     description: 'If true, copies the Pattern CLI to /usr/bin'
     required: false
-    default: false
+    default: 'true'
   setup_gke_cloud_auth:
     description: 'If true, sets up Google Cloud SDK auth plugin'
     required: false
-    default: true
+    default: 'true'
   setup_bazel:
     description: 'If true, sets up Bazel'
     required: false
-    default: true
+    default: 'true'
   setup_docker_cli:
     description: 'If true, sets up Docker CLI'
     required: false
-    default: false
+    default: 'false'
   setup_kubectx:
     description: 'If true, sets up kubectx'
     required: false
-    default: true
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -75,18 +70,18 @@ runs:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
 
     - name: Setup GKE GCloud Auth
-      if: ${{ inputs.setup_gke_cloud_auth }}
+      if: ${{ inputs.setup_gke_cloud_auth == 'true' }}
       uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
 
     - name: Setup Bazel
-      if: ${{ inputs.setup_bazel }}
+      if: ${{ inputs.setup_bazel == 'true' }}
       uses: bazel-contrib/setup-bazel@0.15.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
 
     - name: Install kubectx
-      if: ${{ inputs.setup_kubectx }}
+      if: ${{ inputs.setup_kubectx == 'true' }}
       shell: bash
       working-directory: /tmp
       run: |

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth }}
-      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@lb/conslidate_setup_cloud_deps
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
 
     - name: Setup Bazel
       if: ${{ inputs.setup_bazel }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -86,6 +86,8 @@ runs:
       working-directory: /tmp
       run: |
         if ! which kubectx > /dev/null 2>&1; then
-          git clone https://github.com/ahmetb/kubectx
+          if [ ! -d "kubectx" ]; then
+            git clone https://github.com/ahmetb/kubectx
+          fi
           echo "/tmp/kubectx" >> $GITHUB_PATH
         fi

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -40,7 +40,7 @@ inputs:
     description: 'If true, sets up Docker CLI'
     required: false
     default: false
-  setup_docker_kubectx:
+  setup_kubectx:
     description: 'If true, sets up kubectx'
     required: false
     default: true
@@ -48,7 +48,7 @@ runs:
   using: "composite"
   steps:
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.docker_user }}
         password: ${{ inputs.docker_password }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -1,3 +1,6 @@
+# TODO(lou): currently the only differences between this action and setup_cloud_deps_base
+#            are the default values for what all it does. Does anything break if we set
+#            all of the defaults to true and by default install everything?
 name: 'Cloud Dependencies Setup'
 description: 'Installs the various cloud dependencies needed for the build and deploy workflows.'
 inputs:
@@ -21,6 +24,26 @@ inputs:
     description: 'Harbor Registry Password'
     required: true
     type: string
+  pattern_cli_add_to_usr_bin:
+    description: 'If true, copies the Pattern CLI to /usr/bin'
+    required: false
+    default: false
+  setup_gke_cloud_auth:
+    description: 'If true, sets up Google Cloud SDK auth plugin'
+    required: false
+    default: true
+  setup_bazel:
+    description: 'If true, sets up Bazel'
+    required: false
+    default: true
+  setup_docker_cli:
+    description: 'If true, sets up Docker CLI'
+    required: false
+    default: false
+  setup_docker_kubectx:
+    description: 'If true, sets up kubectx'
+    required: false
+    default: true
 runs:
   using: "composite"
   steps:
@@ -43,36 +66,27 @@ runs:
       with:
         repo_access_pat: ${{ inputs.repo_access_pat }}
 
-    - name: Setup Google Cloud SDK apt keys
-      shell: bash
-      run: |
-        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/cloud.google.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
-    - name: Apt Update
-      shell: bash
-      run: sudo apt-get update -y
-
     - name: Setup Kubectl
       uses: azure/setup-kubectl@v4
 
-    - name: Install gke-gcloud-auth-plugin
-      shell: bash
-      run: |
-        sudo apt install -y \
-        google-cloud-sdk-gke-gcloud-auth-plugin \
-        kubectl
-
     - name: Install the Pattern CLI
       uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+      with:
+        add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
+
+    - name: Setup GKE GCloud Auth
+      if: ${{ inputs.setup_gke_cloud_auth }}
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
 
     - name: Setup Bazel
+      if: ${{ inputs.setup_bazel }}
       uses: bazel-contrib/setup-bazel@0.15.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
 
     - name: Install kubectx
+      if: ${{ inputs.setup_kubectx }}
       shell: bash
       working-directory: /tmp
       run: |

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -85,5 +85,7 @@ runs:
       shell: bash
       working-directory: /tmp
       run: |
-        git clone https://github.com/ahmetb/kubectx
-        echo "/tmp/kubectx" >> $GITHUB_PATH
+        if ! which kubectx > /dev/null 2>&1; then
+          git clone https://github.com/ahmetb/kubectx
+          echo "/tmp/kubectx" >> $GITHUB_PATH
+        fi

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -7,43 +7,38 @@ inputs:
   repo_access_pat:
     description: 'GitHub Personal Access Token'
     required: true
-    type: string
   docker_user:
     description: 'Docker Hub Username'
     required: true
-    type: string
   docker_password:
     description: 'Docker Hub Password'
     required: true
-    type: string
   helm_user:
     description: 'Harbor Registry Username'
     required: true
-    type: string
   helm_password:
     description: 'Harbor Registry Password'
     required: true
-    type: string
   pattern_cli_add_to_usr_bin:
     description: 'If true, copies the Pattern CLI to /usr/bin'
     required: false
-    default: false
+    default: 'false'
   setup_gke_cloud_auth:
     description: 'If true, sets up Google Cloud SDK auth plugin'
     required: false
-    default: false
+    default: 'false'
   setup_bazel:
     description: 'If true, sets up Bazel'
     required: false
-    default: false
+    default: 'false'
   setup_docker_cli:
     description: 'If true, sets up Docker CLI'
     required: false
-    default: true
+    default: 'true'
   setup_kubectx:
     description: 'If true, sets up kubectx'
     required: false
-    default: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -75,27 +70,27 @@ runs:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
 
     - name: Setup GKE GCloud Auth
-      if: ${{ inputs.setup_gke_cloud_auth }}
+      if: ${{ inputs.setup_gke_cloud_auth == 'true' }}
       uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
 
     - name: Setup Bazel
-      if: ${{ inputs.setup_bazel }}
+      if: ${{ inputs.setup_bazel == 'true' }}
       uses: bazel-contrib/setup-bazel@0.15.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
 
     - name: Set Up Docker
-      if: ${{ inputs.setup_docker_cli }}
+      if: ${{ inputs.setup_docker_cli == 'true' }}
       uses: docker/setup-buildx-action@v3
 
     - name: Check Docker access
-      if: ${{ inputs.setup_docker_cli }}
+      if: ${{ inputs.setup_docker_cli == 'true' }}
       shell: bash
       run: docker version
 
     - name: Install kubectx
-      if: ${{ inputs.setup_kubectx }}
+      if: ${{ inputs.setup_kubectx == 'true' }}
       shell: bash
       working-directory: /tmp
       run: |

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth }}
-      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@lb/conslidate_setup_cloud_deps
 
     - name: Setup Bazel
       if: ${{ inputs.setup_bazel }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -94,5 +94,7 @@ runs:
       shell: bash
       working-directory: /tmp
       run: |
-        git clone https://github.com/ahmetb/kubectx
-        echo "/tmp/kubectx" >> $GITHUB_PATH
+        if ! which kubectx > /dev/null 2>&1; then
+          git clone https://github.com/ahmetb/kubectx
+          echo "/tmp/kubectx" >> $GITHUB_PATH
+        fi

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -48,7 +48,7 @@ runs:
   using: "composite"
   steps:
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.docker_user }}
         password: ${{ inputs.docker_password }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth }}
-      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@lb/conslidate_setup_cloud_deps
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
 
     - name: Setup Bazel
       if: ${{ inputs.setup_bazel }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -43,7 +43,7 @@ inputs:
   setup_kubectx:
     description: 'If true, sets up kubectx'
     required: false
-    default: true
+    default: false
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -95,6 +95,8 @@ runs:
       working-directory: /tmp
       run: |
         if ! which kubectx > /dev/null 2>&1; then
-          git clone https://github.com/ahmetb/kubectx
+          if [ ! -d "kubectx" ]; then
+            git clone https://github.com/ahmetb/kubectx
+          fi
           echo "/tmp/kubectx" >> $GITHUB_PATH
         fi

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -1,3 +1,6 @@
+# TODO(lou): currently the only differences between this action and setup_cloud_deps
+#            are the default values for what all it does. Does anything break if we set
+#            all of the defaults to true and by default install everything?
 name: 'Cloud Dependencies Setup'
 description: 'Installs the various cloud dependencies needed for the build and deploy workflows.'
 inputs:
@@ -25,6 +28,22 @@ inputs:
     description: 'If true, copies the Pattern CLI to /usr/bin'
     required: false
     default: false
+  setup_gke_cloud_auth:
+    description: 'If true, sets up Google Cloud SDK auth plugin'
+    required: false
+    default: false
+  setup_bazel:
+    description: 'If true, sets up Bazel'
+    required: false
+    default: false
+  setup_docker_cli:
+    description: 'If true, sets up Docker CLI'
+    required: false
+    default: true
+  setup_kubectx:
+    description: 'If true, sets up kubectx'
+    required: false
+    default: true
 runs:
   using: "composite"
   steps:
@@ -50,14 +69,35 @@ runs:
     - name: Setup Kubectl
       uses: azure/setup-kubectl@v4
 
-    - name: Set Up Docker
-      uses: docker/setup-buildx-action@v3
-
-    - name: Check Docker access
-      shell: bash
-      run: docker version
-
     - name: Install the Pattern CLI
       uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
+
+    - name: Setup GKE GCloud Auth
+      if: ${{ inputs.setup_gke_cloud_auth }}
+      uses: Pattern-Labs/.github/.github/actions/gke_cloud_auth@main
+
+    - name: Setup Bazel
+      if: ${{ inputs.setup_bazel }}
+      uses: bazel-contrib/setup-bazel@0.15.0
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+
+    - name: Set Up Docker
+      if: ${{ inputs.setup_docker_cli }}
+      uses: docker/setup-buildx-action@v3
+
+    - name: Check Docker access
+      if: ${{ inputs.setup_docker_cli }}
+      shell: bash
+      run: docker version
+
+    - name: Install kubectx
+      if: ${{ inputs.setup_kubectx }}
+      shell: bash
+      working-directory: /tmp
+      run: |
+        git clone https://github.com/ahmetb/kubectx
+        echo "/tmp/kubectx" >> $GITHUB_PATH

--- a/.github/workflows/aspect_workflows_reusable.yaml
+++ b/.github/workflows/aspect_workflows_reusable.yaml
@@ -181,7 +181,7 @@ jobs:
         with:
           files: bazel-out/_coverage/_coverage_report.dat
           token: ${{ secrets.CODECOV_TOKEN }}
-          functionalities: search # Disable searching for coverage reports. If enabled, it gets confused
+          disable_search: true # Disable searching for coverage reports. If enabled, it gets confused
           # by the bazel convenience symlinks and finds the same coverage report
           # under bazel-out and {workspace}/bazel-out.
       - name: Trigger delivery

--- a/.github/workflows/aspect_workflows_reusable.yaml
+++ b/.github/workflows/aspect_workflows_reusable.yaml
@@ -124,7 +124,7 @@ jobs:
       # Pattern Labs specific setup #
       ###############################
       - name: Pattern Labs Setup
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps_base@lb/conslidate_setup_cloud_deps
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps_base@main
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/aspect_workflows_reusable.yaml
+++ b/.github/workflows/aspect_workflows_reusable.yaml
@@ -124,7 +124,7 @@ jobs:
       # Pattern Labs specific setup #
       ###############################
       - name: Pattern Labs Setup
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps_base@main
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps_base@lb/conslidate_setup_cloud_deps
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [github-hosted-cloud-builder]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -28,7 +28,7 @@ jobs:
           lfs: true
 
       - name: Setup Cloud Deps
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@lb/conslidate_setup_cloud_deps
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@main
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -28,7 +28,7 @@ jobs:
           lfs: true
 
       - name: Setup Cloud Deps
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@main
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@lb/conslidate_setup_cloud_deps
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -44,7 +44,7 @@ jobs:
           lfs: true
 
       - name: Setup Cloud Deps
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@main
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@lb/conslidate_setup_cloud_deps
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -44,7 +44,7 @@ jobs:
           lfs: true
 
       - name: Setup Cloud Deps
-        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@lb/conslidate_setup_cloud_deps
+        uses: Pattern-Labs/.github/.github/actions/setup_cloud_deps@main
         with:
           repo_access_pat: ${{ secrets.REPO_ACCESS_PAT }}
           docker_user: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: [github-hosted-cloud-builder]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [github-hosted-cloud-builder]
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -64,7 +64,7 @@ jobs:
           bazelisk-cache: true
 
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [github-hosted-cloud-builder]
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
           bazelisk-cache: true
 
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with: 
           lfs: true
 


### PR DESCRIPTION
## Description
as part of trying to set up https://github.com/Pattern-Labs/the_cloud/pull/5305, i ran into issues while swapping between the different workflows in here, as they have slightly different implementations

`setup_cloud_deps`:
* installs `pattern_cli`, but doesn't take any parameter to be able to install it to usr bin
* setups gcloud gke auth plugin (via apt)
* sets up Bazel
* setups kubectx

while `setup_cloud_deps_base`:
* sets up Docker CLI

if we want to consolidate these behaviors, i want to take the following steps
- [x] make `setup_cloud_deps` and `setup_cloud_deps_base` have the same api but different default behavior to preserve backwards compatibility
- [ ] test to see what sensible defaults are / still work
- [ ] if the above works, delete one of the workflows and update all references

since it's right before the holidays and i'm about to be out for the next 3 days, i'm gonna leave the implementation here for now to avoid breaking anything, but this will at least provide me the inputs i want to unblock my other PR (which i could technically work around for now but i think this is a cleaner step in the right direction)

### Summary of Changes
- added a bunch of inputs with different defaults so the sequence of steps are the same in both workflows so it doesn't matter which one you call as long as you specify which behavior you want
- removed seemingly redundant `kubectl` via apt in `setup_cloud_deps` (handled by `azure` action)
- added new action that was 3 steps for `gke` gcloud auth setup to be used from each of the workflows
- added `actionlint` config + ran it and fixed stuff
    - versions of outdated actions
    - incorrect param to the `codecov` action

### Customer-Facing Description

## Testing
1. see all usages of all workflows affected by this PR
    -  [setup_cloud_deps](https://github.com/search?q=org%3APattern-Labs%20setup_cloud_deps%40main&type=code)
    -  [setup_cloud_deps_base](https://github.com/search?q=org%3APattern-Labs+setup_cloud_deps_base%40main&type=code)
2. update references in consuming repos and make sure they don't break
    - the_cloud: https://github.com/Pattern-Labs/the_cloud/pull/5341

## Documentation
- comments in workflows + actions as necessary