### PR TITLE
update helm

### DIFF
--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -59,7 +59,7 @@ runs:
         password: ${{ inputs.docker_password }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v4.3.0
+      uses: Azure/setup-helm@v4.3.1
       with:
         version: ${{ inputs.helm_version }}
 

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     # latest version at the time. v4 has breaking changes, will
     # need to test before upgrading
-    default: "v3.18.4"
+    default: "v3.19.4"
   setup_pattern_cli:
     description: "Whether to setup the Pattern CLI."
     required: false

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -19,6 +19,12 @@ inputs:
   helm_password:
     description: "Harbor Registry Password"
     required: true
+  helm_version:
+    description: "Helm version to install"
+    required: false
+    # latest version at the time. v4 has breaking changes, will
+    # need to test before upgrading
+    default: "v3.18.4"
   setup_pattern_cli:
     description: "Whether to setup the Pattern CLI."
     required: false
@@ -54,6 +60,8 @@ runs:
 
     - name: Install Helm
       uses: Azure/setup-helm@v4.3.0
+      with:
+        version: ${{ inputs.helm_version }}
 
     - name: Log in to Harbor Registry
       shell: bash

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -53,7 +53,7 @@ runs:
         password: ${{ inputs.docker_password }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v3
+      uses: Azure/setup-helm@v4.3.0
 
     - name: Log in to Harbor Registry
       shell: bash

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -19,6 +19,12 @@ inputs:
   helm_password:
     description: "Harbor Registry Password"
     required: true
+  helm_version:
+    description: "Helm version to install"
+    required: false
+    # latest version at the time. v4 has breaking changes, will
+    # need to test before upgrading
+    default: "v3.18.4"
   setup_pattern_cli:
     description: "If true, skips the Pattern CLI installation"
     required: false
@@ -54,6 +60,8 @@ runs:
 
     - name: Install Helm
       uses: Azure/setup-helm@v4.3.0
+      with:
+        version: ${{ inputs.helm_version }}
 
     - name: Log in to Harbor Registry
       shell: bash

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -59,7 +59,7 @@ runs:
         password: ${{ inputs.docker_password }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v4.3.0
+      uses: Azure/setup-helm@v4.3.1
       with:
         version: ${{ inputs.helm_version }}
 

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     # latest version at the time. v4 has breaking changes, will
     # need to test before upgrading
-    default: "v3.18.4"
+    default: "v3.19.4"
   setup_pattern_cli:
     description: "If true, skips the Pattern CLI installation"
     required: false

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -53,7 +53,7 @@ runs:
         password: ${{ inputs.docker_password }}
 
     - name: Install Helm
-      uses: Azure/setup-helm@v3
+      uses: Azure/setup-helm@v4.3.0
 
     - name: Log in to Harbor Registry
       shell: bash

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Helm
-        uses: Azure/setup-helm@v4.3.0
+        uses: Azure/setup-helm@v4.3.1
         with:
           version: "v3.18.4"
 

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Helm
-        uses: Azure/setup-helm@v3
+        uses: Azure/setup-helm@v4.3.0
 
       - name: Log in to Harbor Registry
         run: |

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install Helm
         uses: Azure/setup-helm@v4.3.0
+        with:
+          version: "v3.18.4"
 
       - name: Log in to Harbor Registry
         run: |

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Helm
         uses: Azure/setup-helm@v4.3.1
         with:
-          version: "v3.18.4"
+          version: "v3.19.4"
 
       - name: Log in to Harbor Registry
         run: |

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -28,7 +28,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Helm
-        uses: Azure/setup-helm@v4.3.0
+        uses: Azure/setup-helm@v4.3.1
         with:
           version: "v3.18.4"
 

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Helm
         uses: Azure/setup-helm@v4.3.1
         with:
-          version: "v3.18.4"
+          version: "v3.19.4"
 
       - name: Log in to Harbor Registry
         run: |

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -28,7 +28,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install Helm
-        uses: Azure/setup-helm@v3
+        uses: Azure/setup-helm@v4.3.0
 
       - name: Log in to Harbor Registry
         run: |

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install Helm
         uses: Azure/setup-helm@v4.3.0
+        with:
+          version: "v3.18.4"
 
       - name: Log in to Harbor Registry
         run: |


### PR DESCRIPTION
## Description
in https://github.com/Pattern-Labs/the_cloud/pull/5552 i wanted to use a flag that didn't exist yet

update the helm action + make the version configurable, defaulting to the latest stable version (without defaulting to the latest stable, it defaults to v4 which has some potentially drastic changes which we will want at some point but this way we can configure v4 at some point and test

the reason the action has a breaking version change is because it stopped supporting node 16 https://github.com/Azure/setup-helm/releases

### Customer-Facing Description

## Testing

## Documentation

