### PR TITLE
add the ability to select the pattern-cli version across workflows

### DIFF
--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -46,6 +46,10 @@ runs:
         GOBIN=~/.local/bin GOPRIVATE=github.com/Pattern-Labs/* GONOSUMDB=github.com/Pattern-Labs/* \
           go install github.com/Pattern-Labs/pattern_cli/cmd/pattern@"${VERSION}"
 
+    - name: Add Pattern CLI to PATH
+      shell: bash
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
     - name: Make Pattern CLI executable
       shell: bash
       run: chmod +x ~/.local/bin/pattern

--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Go (branch build support)
+      if: inputs.version != 'latest'
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.22"
+
     - name: Make sure .local/bin exists
       shell: bash
       run: mkdir -p ~/.local/bin

--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: true
   version:
-    description: "Pattern CLI version to install (e.g., v0.40.0 or latest)"
+    description: "Pattern CLI version to install (e.g., v0.40.0, latest, or a branch name)"
     required: false
     default: "latest"
 runs:
@@ -19,13 +19,26 @@ runs:
     - name: Download Pattern CLI
       shell: bash
       run: |
-        if [ -z "${{ inputs.version }}" ] || [ "${{ inputs.version }}" = "latest" ]; then
+        VERSION="${{ inputs.version }}"
+        if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
           release_url="https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/latest"
         else
-          release_url="https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/tags/${{ inputs.version }}"
+          release_url="https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/tags/${VERSION}"
         fi
-        url="$(curl -L -n "${release_url}" | jq -r .assets[0].url)"
-        curl -L -n -H "Accept: application/octet-stream" -o ~/.local/bin/pattern "$url"
+        asset_url="$(curl -L -n -s "${release_url}" | jq -r '.assets[0].url // empty')"
+        if [ -n "$asset_url" ]; then
+          curl -L -n -H "Accept: application/octet-stream" -o ~/.local/bin/pattern "$asset_url"
+          exit 0
+        fi
+
+        if ! command -v go >/dev/null 2>&1; then
+          echo "Go is required to build Pattern CLI from ref '${VERSION}'." >&2
+          exit 1
+        fi
+
+        echo "Building Pattern CLI from '${VERSION}'..."
+        GOBIN=~/.local/bin GOPRIVATE=github.com/Pattern-Labs/* GONOSUMDB=github.com/Pattern-Labs/* \
+          go install github.com/Pattern-Labs/pattern_cli/cmd/pattern@"${VERSION}"
 
     - name: Make Pattern CLI executable
       shell: bash

--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "If true, copies the Pattern CLI to /usr/bin"
     required: false
     default: true
+  version:
+    description: "Pattern CLI version to install (e.g., v0.40.0 or latest)"
+    required: false
+    default: "latest"
 runs:
   using: "composite"
   steps:
@@ -15,7 +19,13 @@ runs:
     - name: Download Pattern CLI
       shell: bash
       run: |
-        curl -L -n -H "Accept: application/octet-stream" -o ~/.local/bin/pattern `curl -L -n https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/latest | jq -r .assets[0].url`
+        if [ -z "${{ inputs.version }}" ] || [ "${{ inputs.version }}" = "latest" ]; then
+          release_url="https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/latest"
+        else
+          release_url="https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/tags/${{ inputs.version }}"
+        fi
+        url="$(curl -L -n "${release_url}" | jq -r .assets[0].url)"
+        curl -L -n -H "Accept: application/octet-stream" -o ~/.local/bin/pattern "$url"
 
     - name: Make Pattern CLI executable
       shell: bash

--- a/.github/actions/pattern_cli/action.yml
+++ b/.github/actions/pattern_cli/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: true
   version:
-    description: "Pattern CLI version to install (e.g., v0.40.0, latest, or a branch name)"
+    description: "Pattern CLI version to install (e.g., v1.2.3, latest, or a branch name)"
     required: false
     default: "latest"
 runs:
@@ -16,7 +16,7 @@ runs:
       if: inputs.version != 'latest'
       uses: actions/setup-go@v5
       with:
-        go-version: "1.22"
+        go-version: "1.25"
 
     - name: Make sure .local/bin exists
       shell: bash

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "If true, copies the Pattern CLI to /usr/bin"
     required: false
     default: "true"
+  pattern_cli_version:
+    description: "Pattern CLI version to install"
+    required: false
+    default: "latest"
   setup_gke_cloud_auth:
     description: "If true, sets up Google Cloud SDK auth plugin"
     required: false
@@ -81,6 +85,7 @@ runs:
       uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
+        version: ${{ inputs.pattern_cli_version }}
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth == 'true' }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+      uses: ./.github/actions/pattern_cli
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "true"
   pattern_cli_version:
-    description: "Pattern CLI version to install"
+    description: "Pattern CLI version to install (tag, latest, or branch name)"
     required: false
     default: "latest"
   setup_gke_cloud_auth:

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
+      uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: ./.github/actions/pattern_cli
+      uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "If true, copies the Pattern CLI to /usr/bin"
     required: false
     default: "true"
+  pattern_cli_version:
+    description: "Pattern CLI version to install"
+    required: false
+    default: "latest"
   setup_gke_cloud_auth:
     description: "If true, sets up Google Cloud SDK auth plugin"
     required: false
@@ -81,6 +85,7 @@ runs:
       uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
+        version: ${{ inputs.pattern_cli_version }}
 
     - name: Setup GKE GCloud Auth
       if: ${{ inputs.setup_gke_cloud_auth == 'true' }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+      uses: ./.github/actions/pattern_cli
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "true"
   pattern_cli_version:
-    description: "Pattern CLI version to install"
+    description: "Pattern CLI version to install (tag, latest, or branch name)"
     required: false
     default: "latest"
   setup_gke_cloud_auth:

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
+      uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Install the Pattern CLI
       if: ${{ inputs.setup_pattern_cli == 'true' }}
-      uses: ./.github/actions/pattern_cli
+      uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
       with:
         add_to_usr_bin: ${{ inputs.pattern_cli_add_to_usr_bin }}
         version: ${{ inputs.pattern_cli_version }}

--- a/.github/workflows/aspect_workflows_reusable.yaml
+++ b/.github/workflows/aspect_workflows_reusable.yaml
@@ -55,7 +55,7 @@ on:
         type: boolean
         default: true
       pattern_cli_version:
-        description: Pattern CLI version to install (e.g., v0.40.0 or latest).
+        description: Pattern CLI version to install (tag, latest, or branch name).
         type: string
         default: latest
       delivery-workflow:

--- a/.github/workflows/aspect_workflows_reusable.yaml
+++ b/.github/workflows/aspect_workflows_reusable.yaml
@@ -54,6 +54,10 @@ on:
         description: Whether to setup the Pattern CLI.
         type: boolean
         default: true
+      pattern_cli_version:
+        description: Pattern CLI version to install (e.g., v0.40.0 or latest).
+        type: string
+        default: latest
       delivery-workflow:
         description: The name of the file which contains the delivery workflow
         type: string
@@ -136,6 +140,7 @@ jobs:
           helm_user: ${{ secrets.HELM_USER }}
           helm_password: ${{ secrets.HELM_PASSWORD }}
           setup_pattern_cli: ${{ inputs.setup_pattern_cli }}
+          pattern_cli_version: ${{ inputs.pattern_cli_version }}
 
       - name: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].name }}
         uses: aspect-build/workflows-action@5.15.0

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -11,11 +11,6 @@ on:
         description: tag to tag built images with
         required: true
         type: string
-      pattern_cli_version:
-        description: Pattern CLI version to install (e.g., v0.40.0 or latest).
-        required: false
-        type: string
-        default: latest
       with_cloud_cache:
         description: whether to use the cloud cache
         required: false
@@ -45,7 +40,6 @@ jobs:
           docker_password: ${{ secrets.DOCKER_PASSWORD }}
           helm_user: ${{ secrets.HELM_USER }}
           helm_password: ${{ secrets.HELM_PASSWORD }}
-          pattern_cli_version: ${{ inputs.pattern_cli_version }}
           pattern_cli_version: ${{ inputs.pattern_cli_version }}
 
       - name: Set Up Build Cache Credentials

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -11,11 +11,21 @@ on:
         description: tag to tag built images with
         required: true
         type: string
+      pattern_cli_version:
+        description: Pattern CLI version to install (e.g., v0.40.0 or latest).
+        required: false
+        type: string
+        default: latest
       with_cloud_cache:
         description: whether to use the cloud cache
         required: false
         type: boolean
         default: false
+      pattern_cli_version:
+        description: Pattern CLI version to install
+        required: false
+        type: string
+        default: latest
 
 jobs:
   build-molecule:
@@ -35,6 +45,8 @@ jobs:
           docker_password: ${{ secrets.DOCKER_PASSWORD }}
           helm_user: ${{ secrets.HELM_USER }}
           helm_password: ${{ secrets.HELM_PASSWORD }}
+          pattern_cli_version: ${{ inputs.pattern_cli_version }}
+          pattern_cli_version: ${{ inputs.pattern_cli_version }}
 
       - name: Set Up Build Cache Credentials
         if: ${{ inputs.with_cloud_cache }}

--- a/.github/workflows/build_molecule.yaml
+++ b/.github/workflows/build_molecule.yaml
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: false
       pattern_cli_version:
-        description: Pattern CLI version to install
+        description: Pattern CLI version to install (tag, latest, or branch name)
         required: false
         type: string
         default: latest

--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -33,7 +33,7 @@ on:
         default: "rutherford"
         type: string
       pattern_cli_version:
-        description: Pattern CLI version to install
+        description: Pattern CLI version to install (tag, latest, or branch name)
         required: false
         type: string
         default: latest

--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         default: "rutherford"
         type: string
+      pattern_cli_version:
+        description: Pattern CLI version to install
+        required: false
+        type: string
+        default: latest
 
 jobs:
   deploy-molecule:
@@ -51,6 +56,7 @@ jobs:
           docker_password: ${{ secrets.DOCKER_PASSWORD }}
           helm_user: ${{ secrets.HELM_USER }}
           helm_password: ${{ secrets.HELM_PASSWORD }}
+          pattern_cli_version: ${{ inputs.pattern_cli_version }}
 
       - name: Establish Google Cloud Auth
         id: "auth"

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.REPO_ACCESS_PAT }}
 
       - name: Install the Pattern CLI
-        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+        uses: ./.github/actions/pattern_cli
         with:
           version: ${{ inputs.pattern_cli_version }}
 

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -11,6 +11,11 @@ on:
         description: coverage percentage we should fail on
         required: true
         type: number
+      pattern_cli_version:
+        description: Pattern CLI version to install
+        required: false
+        type: string
+        default: latest
 
 jobs:
   test-molecule:
@@ -54,10 +59,9 @@ jobs:
           password: ${{ secrets.REPO_ACCESS_PAT }}
 
       - name: Install the Pattern CLI
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L -n -H "Accept: application/octet-stream" -o $HOME/.local/bin/pattern `curl -L -n https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/latest | jq -r .assets[0].url`
-          chmod +x $HOME/.local/bin/pattern
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+        with:
+          version: ${{ inputs.pattern_cli_version }}
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.9.1

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -12,7 +12,7 @@ on:
         required: true
         type: number
       pattern_cli_version:
-        description: Pattern CLI version to install
+        description: Pattern CLI version to install (tag, latest, or branch name)
         required: false
         type: string
         default: latest

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.REPO_ACCESS_PAT }}
 
       - name: Install the Pattern CLI
-        uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
         with:
           version: ${{ inputs.pattern_cli_version }}
 

--- a/.github/workflows/molecule_coverage.yaml
+++ b/.github/workflows/molecule_coverage.yaml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.REPO_ACCESS_PAT }}
 
       - name: Install the Pattern CLI
-        uses: ./.github/actions/pattern_cli
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
         with:
           version: ${{ inputs.pattern_cli_version }}
 

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       pattern_cli_version:
-        description: Pattern CLI version to install
+        description: Pattern CLI version to install (tag, latest, or branch name)
         required: false
         type: string
         default: latest

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -64,7 +64,7 @@ jobs:
 
 
       - name: Install the Pattern CLI
-        uses: ./.github/actions/pattern_cli
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
         with:
           version: ${{ inputs.pattern_cli_version }}
 

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -15,6 +15,11 @@ on:
         description: tag to tag release chart with
         required: true
         type: string
+      pattern_cli_version:
+        description: Pattern CLI version to install
+        required: false
+        type: string
+        default: latest
     
 jobs:
   release-molecule:
@@ -59,10 +64,9 @@ jobs:
 
 
       - name: Install the Pattern CLI
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L -n -H "Accept: application/octet-stream" -o $HOME/.local/bin/pattern `curl -L -n https://api.github.com/repos/Pattern-Labs/pattern_cli/releases/latest | jq -r .assets[0].url`
-          chmod +x $HOME/.local/bin/pattern
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+        with:
+          version: ${{ inputs.pattern_cli_version }}
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.9.1

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -64,7 +64,7 @@ jobs:
 
 
       - name: Install the Pattern CLI
-        uses: Pattern-Labs/.github/.github/actions/pattern_cli@feat/kts/pattern-cli-version-selector
+        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
         with:
           version: ${{ inputs.pattern_cli_version }}
 

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -64,7 +64,7 @@ jobs:
 
 
       - name: Install the Pattern CLI
-        uses: Pattern-Labs/.github/.github/actions/pattern_cli@main
+        uses: ./.github/actions/pattern_cli
         with:
           version: ${{ inputs.pattern_cli_version }}
 


### PR DESCRIPTION
## Description
Enhance the pattern_cli related workflows to allow setting a particular version, tag, or branch to install. 

## Testing
As part of [this branch](https://github.com/Pattern-Labs/the_cloud/pull/6660). 
