### PR TITLE
harbor to dockerhub

### DIFF
--- a/.github/actions/setup_cloud_deps/action.yml
+++ b/.github/actions/setup_cloud_deps/action.yml
@@ -70,7 +70,7 @@ runs:
     - name: Log in to Harbor Registry
       shell: bash
       run: |
-        echo '${{ inputs.helm_password }}' | helm registry login harbor.rutherford.patternlabs.tech -u '${{ inputs.helm_user }}' --password-stdin
+        echo '${{ inputs.docker_password }}' | helm registry login registry-1.docker.io -u '${{ inputs.docker_user }}' --password-stdin
 
     - name: Setup .netrc
       uses: Pattern-Labs/.github/.github/actions/setup_netrc@main

--- a/.github/actions/setup_cloud_deps_base/action.yml
+++ b/.github/actions/setup_cloud_deps_base/action.yml
@@ -70,7 +70,7 @@ runs:
     - name: Log in to Harbor Registry
       shell: bash
       run: |
-        echo '${{ inputs.helm_password }}' | helm registry login harbor.rutherford.patternlabs.tech -u '${{ inputs.helm_user }}' --password-stdin
+        echo '${{ inputs.docker_password }}' | helm registry login registry-1.docker.io -u '${{ inputs.docker_user }}' --password-stdin
 
     - name: Setup .netrc
       uses: Pattern-Labs/.github/.github/actions/setup_netrc@main

--- a/.github/workflows/release_molecule.yaml
+++ b/.github/workflows/release_molecule.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: latest
+      helm_oci_repo:
+        description: OCI repo to push the chart to (overrides the CLI's default of Docker Hub)
+        required: false
+        type: string
+        default: ""
     
 jobs:
   release-molecule:
@@ -36,6 +41,10 @@ jobs:
         uses: Azure/setup-helm@v4.3.1
         with:
           version: "v3.19.4"
+
+      - name: Log in to Docker Hub for Helm
+        run: |
+           echo '${{ secrets.DOCKER_PASSWORD }}' | helm registry login registry-1.docker.io -u '${{ secrets.DOCKER_USER }}' --password-stdin
 
       - name: Log in to Harbor Registry
         run: |
@@ -80,6 +89,8 @@ jobs:
           lfs: true
 
       - name: Release Molecule
+        env:
+          HELM_OCI_REPO: ${{ inputs.helm_oci_repo }}
         run: |
           cd ${{ inputs.molecule_path }}
           pattern molecule release ${{ inputs.chart_name}} ${{ inputs.tag }}


### PR DESCRIPTION
## Description
https://github.com/Pattern-Labs/the_cloud/issues/3149

inventoried all the users of this action, none of them actually write to dockerhub, so we can do this as part of the "readers" step of the migration plan

provides support for HELM_OCI_REPO which gets introduced in pattern cli https://github.com/Pattern-Labs/pattern_cli/pull/249

### Customer-Facing Description

## Testing
described in testing-plan.md in the ticket. for the purposes of this PR:
- [ ] https://github.com/Pattern-Labs/the_cloud/pull/9140 opened a PR pointing at this, everything passes(? TODO)

## Documentation