### PR TITLE
only init cluster_name

### DIFF
--- a/.github/workflows/deploy_molecule.yaml
+++ b/.github/workflows/deploy_molecule.yaml
@@ -30,7 +30,7 @@ on:
       cluster_name:
         description: name of the cluster to deploy to
         required: false
-        default: "rutherford"
+        default: "dalton"
         type: string
       pattern_cli_version:
         description: Pattern CLI version to install (tag, latest, or branch name)
@@ -71,7 +71,7 @@ jobs:
           install_components: "gke-gcloud-auth-plugin"
 
       - name: Pattern Clusters Init
-        run: pattern clusters init
+        run: pattern clusters init --clusters ${{ inputs.cluster_name }}
 
       - name: Switch to the right cluster
         run: kubectx ${{ inputs.cluster_name }}


### PR DESCRIPTION
## Description
consuming workflows failing on `init`ing unnecessary clusters

https://pattern-labs.slack.com/archives/C033VKY5QKY/p1788275481569479?thread_ts=1788186609.688509&cid=C033VKY5QKY

### Customer-Facing Description

## Testing
- [x] test with [the_cloud PR](https://github.com/Pattern-Labs/the_cloud/pull/9551)

risk: this breaks other repos that aren't the cloud
mitigation: [search org for this workflow](https://github.com/search?q=org%3APattern-Labs+deploy_molecule.yaml&type=code) and there are only 6 references: `the_cloud`, `molecule` (deprecated), `random`. fine just managing the_cloud here 

## Documentation
